### PR TITLE
gemspec: Drop unused test_files directive

### DIFF
--- a/pg_trunk.gemspec
+++ b/pg_trunk.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   spec.metadata["rubygems_mfa_required"] = "true"
 
   spec.files = `git ls-files -z`.split("\x0")
-  spec.test_files = spec.files.grep(%r{^spec/})
   spec.require_paths = ["lib"]
 
   spec.add_dependency "activerecord", ">= 4.0.0"


### PR DESCRIPTION
RubyGems.org does not use this directive for anything.